### PR TITLE
Adds BrowserMode

### DIFF
--- a/lib/miq_performance/browser_mode_middleware.rb
+++ b/lib/miq_performance/browser_mode_middleware.rb
@@ -1,0 +1,40 @@
+require "fileutils"
+require "miq_performance/configuration"
+
+# This middleware wraps the existing `miq_performance/middleware` and allows
+# for triggering that middleware from either a URL param, or have it always
+# trigger the performance middleware.
+#
+# This is not enabled by default, and needs to be configured to have it
+# included in the stack.
+module MiqPerformance
+  class BrowserModeMiddleware
+    def initialize app
+      @app = app
+      set_performance_middleware_proc
+    end
+
+    def call env
+      if enable_performance_middleware?
+        env[Middleware::PERFORMANCE_HEADER] = "true"
+      end
+      @app.call env
+    end
+
+    private
+
+    def enabled_performance_middleware?
+      @enable_performance_middleware.call
+    end
+
+    def set_performance_middleware_proc
+      if MiqPerformance.config.browser_mode.always_on?
+        @enable_performance_middleware = proc { |env| true }
+      else
+        @enable_performance_middleware = proc do |env|
+          env["QUERY_STRING"].include? "miq_performance_profile=true"
+        end
+      end
+    end
+  end
+end

--- a/lib/miq_performance/configuration.rb
+++ b/lib/miq_performance/configuration.rb
@@ -2,12 +2,15 @@ require "yaml"
 
 module MiqPerformance
   class Configuration
-    REQUESTOR_CONFIG  = Struct.new :username,
-                                   :password,
-                                   :host,
-                                   :read_timeout,
-                                   :ignore_ssl,
-                                   :requestfile_dir
+    REQUESTOR_CONFIG     = Struct.new :username,
+                                      :password,
+                                      :host,
+                                      :read_timeout,
+                                      :ignore_ssl,
+                                      :requestfile_dir
+
+    BROWSER_MODE_CONFIG  = Struct.new :enabled?,
+                                      :always_on?
 
     DEFAULTS = {
       "default_dir"          => "tmp/miq_performance",
@@ -27,10 +30,16 @@ module MiqPerformance
         active_support_timers
         active_record_queries
       ],
-      "middleware_storage"   => %w[file]
+      "middleware_storage"   => %w[file],
+      "browser_mode"  => {
+        "enabled"   => false,
+        "always_on" => false
+      }
     }.freeze
 
-    attr_reader :default_dir, :log_dir, :requestor, :middleware, :middleware_storage
+    attr_reader :default_dir, :log_dir, :requestor,
+                :middleware, :middleware_storage,
+                :browser_mode
 
     def self.load_config
       new load_config_file
@@ -58,6 +67,7 @@ module MiqPerformance
       @requestor          = requestor_config config.fetch("requestor", {})
       @middleware         = self["middleware"]
       @middleware_storage = self["middleware_storage"]
+      @browser_mode       = browser_mode_config config.fetch("browser_mode", {})
     end
 
     def [](key)
@@ -108,6 +118,14 @@ module MiqPerformance
         (opts["read_timeout"] || defaults["read_timeout"]),
         (opts["ignore_ssl"]   || defaults["ignore_ssl"]),
         (opts["requestfile_dir"])
+      )
+    end
+
+    def browser_mode_config(opts={})
+      defaults = DEFAULTS["browser_mode"]
+      BROWSER_MODE_CONFIG.new(
+        (opts["enabled"]   || defaults["enabled"]),
+        (opts["always_on"] || defaults["always_on"])
       )
     end
   end

--- a/lib/miq_performance/railtie/middleware.rb
+++ b/lib/miq_performance/railtie/middleware.rb
@@ -6,6 +6,11 @@ module MiqPerformance
       # Make this the first middleware in the stack.
       # TODO: Make this order independent
       app.middleware.unshift MiqPerformance::Middleware
+
+      if MiqPerformance.config.browser_mode.enabled?
+        require 'miq_performance/browser_mode_middleware'
+        app.middleware.insert_before "MiqPerformance::Middleware", "MiqPerformance::BrowserModeMiddleware"
+      end
     end
   end
 end

--- a/spec/miq_performance/configuration_spec.rb
+++ b/spec/miq_performance/configuration_spec.rb
@@ -149,6 +149,16 @@ describe MiqPerformance::Configuration do
       expect(MiqPerformance.config.middleware_storage).to match_array(middleware_storage)
       expect(MiqPerformance.config["middleware_storage"]).to match_array(middleware_storage)
     end
+
+    it "defines MiqPerformance.config.browser_mode.enabled?" do
+      expect(MiqPerformance.config.browser_mode.enabled?).to eq(false)
+      expect(MiqPerformance.config["browser_mode"]["enabled"]).to eq(false)
+    end
+
+    it "defines MiqPerformance.config.browser_mode.always_on?" do
+      expect(MiqPerformance.config.browser_mode.always_on?).to eq(false)
+      expect(MiqPerformance.config["browser_mode"]["always_on"]).to eq(false)
+    end
   end
 
   describe "loading from a yaml file" do
@@ -174,6 +184,9 @@ describe MiqPerformance::Configuration do
         middleware_storage:
           - file
           - log
+        browser_mode:
+          enabled: true
+          always_on: true
       YAML
     }
     before(:each) do
@@ -245,6 +258,16 @@ describe MiqPerformance::Configuration do
       middleware_storage = %w[file log]
       expect(MiqPerformance.config.middleware_storage).to match_array(middleware_storage)
       expect(MiqPerformance.config["middleware_storage"]).to match_array(middleware_storage)
+    end
+
+    it "defines MiqPerformance.config.browser_mode.enabled?" do
+      expect(MiqPerformance.config.browser_mode.enabled?).to eq(true)
+      expect(MiqPerformance.config["browser_mode"]["enabled"]).to eq(true)
+    end
+
+    it "defines MiqPerformance.config.browser_mode.always_on?" do
+      expect(MiqPerformance.config.browser_mode.always_on?).to eq(true)
+      expect(MiqPerformance.config["browser_mode"]["always_on"]).to eq(true)
     end
   end
 

--- a/spec/miq_performance/middleware_storage/log_spec.rb
+++ b/spec/miq_performance/middleware_storage/log_spec.rb
@@ -8,8 +8,13 @@ describe MiqPerformance::MiddlewareStorage::Log do
   before do
     allow(Time).to receive(:now).and_return("1234567")
 
-    requestor_defaults = MiqPerformance::Configuration::DEFAULTS["requestor"]
-    new_defaults = {"requestor" => requestor_defaults}.merge "log_dir" => "tmp/log"
+    requestor_defaults    = MiqPerformance::Configuration::DEFAULTS["requestor"]
+    browser_mode_defaults = MiqPerformance::Configuration::DEFAULTS["browser_mode"]
+    new_defaults = {
+      "requestor"    => requestor_defaults,
+      "browser_mode" => browser_mode_defaults
+    }.merge "log_dir" => "tmp/log"
+
     stub_const("MiqPerformance::Configuration::DEFAULTS", new_defaults)
   end
 


### PR DESCRIPTION
## Purpose

Allow for users to interact with the performance middleware from the browser, specifically, enabling it on a given request via an url query parameter.
## Implementation Details

Currently, this adds another Rack Middleware, that is disabled by default, that will either:
- Analyze the query params and if `miq_performance_profile=true` is found, then it will trigger the MiqPerformance::Middleware by adding the necessary HTTP header to trigger it in the Rack `env`
- It can be configured to be `always_on` to capture every request

This allows for the existing middleware to still remain lightweight, but allow for a developer centric workflow that doesn't require using the CLI to trigger requests.

Future additions to this middleware could allow for adding a html widget to the page that shows current performance statistics for this page, and previous statistics from other runs.
